### PR TITLE
Set WTForms version to 2.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install python3-pip
 
 RUN pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir flask wtforms
+    pip3 install --no-cache-dir flask wtforms==2.3.3
 
 WORKDIR /build/polem
 COPY rest-api /build/polem/rest-api


### PR DESCRIPTION
In WTForms versions 3 and above the TextField alias is deprecated.
See: https://wtforms.readthedocs.io/en/3.0.x/whats_new/?highlight=textfield#wtforms-2

Resolves #6 